### PR TITLE
Preserve timezone offset when parsing datetime properties

### DIFF
--- a/aiowmi/dtypes/dt.py
+++ b/aiowmi/dtypes/dt.py
@@ -3,7 +3,7 @@ from typing import Union
 from datetime import datetime, timedelta
 
 
-_FMT = '%Y%m%d%H%M%S.%f'
+_FMT = '%Y%m%d%H%M%S.%f%z'
 
 
 def dt_from_str(s: str) -> Union[datetime, timedelta]:
@@ -49,12 +49,7 @@ def dt_from_str(s: str) -> Union[datetime, timedelta]:
             if s[t:e] == '00':
                 s = s[:t] + '01' + s[e:]
 
-        dt = datetime.strptime(s[:21], _FMT)
-        if s[-4] == '+':
-            dt -= timedelta(hours=hours, minutes=minutes)
-        else:
-            assert s[-4] == '-'
-            dt += timedelta(hours=hours, minutes=minutes)
+        dt = datetime.strptime(f"{s[:21]}{s[-4]}{hours:02}{minutes:02}", _FMT)
 
     except Exception as e:
         logging.debug(


### PR DESCRIPTION
## Description

For my use case I would highly prefer to have the timezone offset preserved in the resulting datetime objects when properties are parsed.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This change could break code that does not handle the timezone offset of the datetime data type.

## How Has This Been Tested?

Since there are no unit test, I only tested the code in my specific use case.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Disclaimer

I'm a python noob, so please elaborate on potential mistakes I made.